### PR TITLE
Develop the report output logic and tests

### DIFF
--- a/log_monitor.py
+++ b/log_monitor.py
@@ -97,6 +97,29 @@ def monitor_jobs(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             del jobs[pid]
     return reports
 
+def log_report(reports: List[Dict[str, Any]], report_file: str) -> None:
+    """
+    Writes warnings and errors to the report file based on job durations.
+
+    For each job report:
+        - Logs a warning if the job took longer than 5 minutes.
+        - Logs an error if the job took longer than 10 minutes.
+
+    Args:
+        reports (List[Dict[str, Any]]): List of job report dictionaries.
+        report_file (str): Path to the output report file.
+    """
+    with open(report_file, "w") as f:
+        for job in reports:
+            duration_str = str(job["duration"])
+            print('Checking PID ', job["pid"], ' task duration: ', job["duration"])
+            if job["duration"] > ERROR_THRESHOLD:
+                f.write(f"ERROR: Job {job['pid']} ({job['description']}) took {duration_str}\n")
+                print(f"ERROR: Job {job['pid']} ({job['description']}) took {duration_str}\n")
+            elif job["duration"] > WARNING_THRESHOLD:
+                f.write(f"WARNING: Job {job['pid']} ({job['description']}) took {duration_str}\n")
+                print(f"WARNING: Job {job['pid']} ({job['description']}) took {duration_str}\n")
+
 def main() -> None:
     """
     Main entry point for the log monitoring application.
@@ -109,6 +132,9 @@ def main() -> None:
     entries = parse_log(get_log_lines(LOG_FILE))
     print('--- Calling monitor_jobs to track jobs by PID, calculate durations and return a list of job reports. ')
     reports = monitor_jobs(entries)
+    print('--- Calling log_report to write warnings and errors to the report file based on job durations.')
+    log_report(reports, REPORT_FILE)
+    print(f"Monitoring complete. See {REPORT_FILE} for warnings and errors.")
     
 if __name__ == "__main__":
     main()

--- a/test_log_monitor.py
+++ b/test_log_monitor.py
@@ -76,5 +76,56 @@ class TestLogMonitor(unittest.TestCase):
         self.assertEqual(reports[1]["duration"], timedelta(minutes=6))
         self.assertEqual(reports[2]["duration"], timedelta(minutes=11))
 
+    def test_log_report(self):
+        """
+        Test that log_report writes warnings and errors for jobs exceeding thresholds,
+        and does not write for jobs under the threshold.
+
+        Checks that only jobs exceeding the warning or error thresholds are reported,
+        and that the correct messages are written to the report.
+        """
+        reports = [
+            {"pid": "1", "description": "Job A", "duration": timedelta(minutes=4, seconds=59)},
+            {"pid": "2", "description": "Job B", "duration": timedelta(minutes=6)},
+            {"pid": "3", "description": "Job C", "duration": timedelta(minutes=11)},
+        ]
+        m = mock_open()
+        with patch("builtins.open", m):
+            log_monitor.log_report(reports, "report.log")
+        handle = m()
+        handle.write.assert_has_calls([
+            call("WARNING: Job 2 (Job B) took 0:06:00\n"),
+            call("ERROR: Job 3 (Job C) took 0:11:00\n"),
+        ], any_order=True)
+        written = "".join(call_arg[0][0] for call_arg in handle.write.call_args_list)
+        self.assertNotIn("Job 1", written)
+
+    def test_threshold_boundaries(self):
+        """
+        Test that jobs just over 5 minutes log a warning,
+        jobs just over 10 minutes log an error,
+        and jobs at or below thresholds are not reported.
+
+        - Job D: exactly 5 min (no log)
+        - Job E: just over 5 min (warning)
+        - Job F: exactly 10 min (warning)
+        - Job G: just over 10 min (error)
+        """
+        reports = [
+            {"pid": "4", "description": "Job D", "duration": timedelta(minutes=WARNING_THRESHOLD_MINS)},           # Exactly warning threshold: no log
+            {"pid": "5", "description": "Job E", "duration": timedelta(minutes=WARNING_THRESHOLD_MINS, seconds=1)},# Just over warning threshold: warning
+            {"pid": "6", "description": "Job F", "duration": timedelta(minutes=ERROR_THRESHOLD_MINS)},          # Exactly error threshold: warning
+            {"pid": "7", "description": "Job G", "duration": timedelta(minutes=ERROR_THRESHOLD_MINS, seconds=1)} # Just over error threshold: error
+        ]
+        m = mock_open()
+        with patch("builtins.open", m):
+            log_monitor.log_report(reports, "report.log")
+        handle = m()
+        written = "".join(call_arg[0][0] for call_arg in handle.write.call_args_list)
+        self.assertNotIn("Job D", written)  # No log for exactly 5 min
+        self.assertIn("WARNING: Job 5 (Job E)", written)  # Warning for just over 5 min
+        self.assertIn("WARNING: Job 6 (Job F)", written)  # Warning for exactly 10 min
+        self.assertIn("ERROR: Job 7 (Job G)", written)    # Error for just over 10 min
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This pull request implements the core functionality of the Log Monitoring Application:
- Writes warnings and errors to the report file based on job durations.
- For each job report:
   - Logs a warning if the job took longer than 5 minutes.
   - Logs an error if the job took longer than 10 minutes.

## Changes

> Develop task duration tests: 

Developed functions in test_log_monitor.py: 
test_log_report: Test that log_report writes warnings and errors for jobs exceeding thresholds,        and does not write for jobs under the threshold.
test_threshold_boundaries: Test that jobs just over 5 minutes log a warning, jobs just over 10 minutes log an error, and jobs at or below thresholds are not reported.

> Developed task duration functionality:

Develop functions in log_monitory.py:
log_report: Writes warnings and errors to the report file based on job durations.

## Related Issue

Closes #7 

## How to Test

1. Check the test data in test_log_monitor.py:

2. Run the app:
    ```
    python log_monitor.py
    ```
3. Check `report.log` for expected warning and error:
    
	test_log_report:    
	```
    WARNING: Job 2 (Job B) took 0:06:00
	ERROR: Job 3 (Job C) took 0:11:00
    ```

    test_threshold_boundaries.py:      
	```
    WARNING: Job 5 (Job E) took 0:05:01
	WARNING: Job 6 (Job F) took 0:10:00
	ERROR: Job 7 (Job G) took 0:10:01
    ```


## Notes

- Uses functional style with no external dependencies